### PR TITLE
fix truthiness issue leading to OAuth memberships being prematurely approved

### DIFF
--- a/Osmf/Membership.php
+++ b/Osmf/Membership.php
@@ -30,9 +30,9 @@ class Membership {
       return;
     }
 
-    $contributionPageId = $params['contribution']->contribution_page_id ?? NULL;
-    $membershipId = $params['id'] ?? NULL;
-    $contactId = $params['contact_id'] ?? NULL;
+    $contributionPageId = (int) $params['contribution']->contribution_page_id ?? NULL;
+    $membershipId = (int) $params['id'] ?? NULL;
+    $contactId = (int) $params['contact_id'] ?? NULL;
 
     if (self::weAreProcessingAContributionPageSubmission(
       $contributionPageId, $membershipId, $contactId)) {
@@ -57,9 +57,9 @@ class Membership {
   }
 
   private static function weAreProcessingAContributionPageSubmission(
-    $contributionPageId,
-    $membershipId,
-    $contactId): bool {
+    int $contributionPageId,
+    int $membershipId,
+    int $contactId): bool {
     return !empty($contributionPageId)
     || (!empty($membershipId) && $membershipId === self::$submittedFormVals['membershipId'])
     || (!empty($contactId) && $contactId === self::$submittedFormVals['contactId']);


### PR DESCRIPTION
When someone signs up for an Active Contributor membership, the membership is supposed to stay pending until the OAuth is complete. It's being marked as active immediately.  This patch fixes that.